### PR TITLE
Substrait consumer build fix

### DIFF
--- a/cpp/src/arrow/engine/CMakeLists.txt
+++ b/cpp/src/arrow/engine/CMakeLists.txt
@@ -122,8 +122,7 @@ add_arrow_lib(arrow_engine
               ${SUBSTRAIT_GEN_DIR})
 
 foreach(LIB_TARGET ${ARROW_ENGINE_LIBRARIES})
-  target_compile_definitions(${LIB_TARGET} PRIVATE ARROW_ENGINE_EXPORTING
-                                                   LIBPROTOBUF_EXPORTS)
+  target_compile_definitions(${LIB_TARGET} PRIVATE ARROW_ENGINE_EXPORTING)
 endforeach()
 
 set(ARROW_ENGINE_TEST_LINK_LIBS ${ARROW_ENGINE_LINK_lIBS} ${ARROW_TEST_LINK_LIBS})


### PR DESCRIPTION
Well, after banging my head against the wall trying different things I managed to discover what I think is the problem.  Luckily the fix is a 1 word fix.

The cmake flag `LIBPROTOBUF_EXPORTS` appears to no longer be required.  I think the default now is to always export symbols.  However, if you specify `LIBPROTOBUF_EXPORTS` and you do not specify `PROTOBUF_USE_DLLS` it will actually remove the exporting.  Based on [this comment](https://github.com/protocolbuffers/protobuf/blob/3bdcc1266b65e10a61d398ba15bfbec612cbdb5d/src/google/protobuf/stubs/port.h#L91) I'm thinking the better approach is to specify neither flag.

Once that was resolved then the Windows build still failed because it runs the examples and the example failed.  I had to touch up a few things to get the example passing.  It turns out there was an Arrow bug interfering with filter pushdown (ARROW-12311) so I removed the filter.  Also, the files probably won't exist so I changed the example to take in a parquet filename.  I made it fake-pass (as we do in some other examples) if no filename is specified.  Also, my earlier statement (scan_options.projection is never used) turned out to be not quite accurate.  Rather than add that projection logic back in I fixed the scanner to handle the case where no projection is specified.