### PR TITLE
If we build protobuf from source we always build it statically.  We n…

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -1426,6 +1426,11 @@ macro(build_protobuf)
   set(PROTOBUF_VENDORED TRUE)
   set(PROTOBUF_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/protobuf_ep-install")
   set(PROTOBUF_INCLUDE_DIR "${PROTOBUF_PREFIX}/include")
+  # This flag is based on what the user initially requested but if
+  # we've fallen back to building protobuf we always build it statically
+  # so we need to reset the flag so that we can link against it correctly
+  # later.
+  set(Protobuf_USE_STATIC_LIBS ON)
   # Newer protobuf releases always have a lib prefix independent from CMAKE_STATIC_LIBRARY_PREFIX
   set(PROTOBUF_STATIC_LIB
       "${PROTOBUF_PREFIX}/lib/libprotobuf${CMAKE_STATIC_LIBRARY_SUFFIX}")
@@ -1532,7 +1537,7 @@ if(ARROW_WITH_PROTOBUF)
                      PC_PACKAGE_NAMES
                      protobuf)
 
-  if(ARROW_PROTOBUF_USE_SHARED AND MSVC_TOOLCHAIN)
+  if(NOT Protobuf_USE_STATIC_LIBS AND MSVC_TOOLCHAIN)
     add_definitions(-DPROTOBUF_USE_DLLS)
   endif()
 


### PR DESCRIPTION
…eed to reset the USE_STATIC_LIBS flag so that downstream components know it was built statically even if a shared library was requested.